### PR TITLE
Extend errors with a key -> server mapping context

### DIFF
--- a/lib/memcached/exceptions.rb
+++ b/lib/memcached/exceptions.rb
@@ -65,7 +65,18 @@ Subclasses correspond one-to-one with server response strings or libmemcached er
   # Generate exception classes
   Lib::MEMCACHED_MAXIMUM_RETURN.times do |index|
     description = Lib.memcached_strerror(empty_struct, index).gsub("!", "")
-    exception_class = eval("class #{camelize(description)} < Error; self; end")
+    exception_class = eval("""
+      class #{camelize(description)} < Error
+        attr_reader :key_map
+
+        def initialize(msg, key_map: nil)
+          @key_map = key_map
+          super(msg)
+        end
+
+        self
+      end
+    """)
     EXCEPTIONS << exception_class
   end
 

--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -600,7 +600,8 @@ But it was #{server}.
   end
 
   def reraise(key, ret)
-    message = "Key #{inspect_keys(key, (detect_failure if ret == Lib::MEMCACHED_SERVER_MARKED_DEAD)).inspect}" if key
+    key_map = inspect_keys(key, (detect_failure if ret == Lib::MEMCACHED_SERVER_MARKED_DEAD)) if key
+    message = "Key #{key_map.inspect}" if key_map
     if key.is_a?(String)
       if ret == Lib::MEMCACHED_ERRNO
         if (server = Lib.memcached_server_by_key(@struct, key)).is_a?(Array)
@@ -614,7 +615,7 @@ But it was #{server}.
       end
     end
     if EXCEPTIONS[ret]
-      raise EXCEPTIONS[ret], message
+      raise EXCEPTIONS[ret].new(message, key_map: key_map)
     else
       raise Memcached::Error, "Unknown return code: #{ret}"
     end

--- a/test/unit/memcached_test.rb
+++ b/test/unit/memcached_test.rb
@@ -1179,6 +1179,8 @@ class MemcachedTest < Test::Unit::TestCase
     rescue => e
       assert_equal Memcached::ServerIsMarkedDead, e.class
       assert_match(/localhost:43041/, e.message)
+      assert_equal 1, e.key_map.size
+      assert_match(/localhost:43041/, e.key_map[key2])
     end
 
     # Hit first server on retry


### PR DESCRIPTION
To generate metrics based on observed errors that use the key and/or server, currently users need to do something like parse the message or override the `check_return_code` in order to hook into a place where they can attempt to observe the key used and infer the server involved similar to how the message is generated. This is additionally tricky around the `ServerIsMarkedDead` errors, since naively calling `server_by_key` would return the incorrect server (handled by `detect_failure` as part of message generation).

To ease users ability to track the keys and servers that errors are related to, this extends the base error class and attaches the same context applied to the messages to an attribute `key_map`.

As far as I can tell there's no differentiation between server-side and client-side errors, so the `key_map`'s semantics are roughly "these were the keys used as part of this operation, and these are the servers we think would have been used with these keys"...a little wishy-washy but likely still useful to the user?