### PR TITLE
Avoid memory leak

### DIFF
--- a/lib/memcached/exceptions.rb
+++ b/lib/memcached/exceptions.rb
@@ -60,7 +60,6 @@ Subclasses correspond one-to-one with server response strings or libmemcached er
 
   EXCEPTIONS = []
   empty_struct = Lib.memcached_create(nil)
-  Lib.memcached_create(empty_struct)
 
   # Generate exception classes
   Lib::MEMCACHED_MAXIMUM_RETURN.times do |index|


### PR DESCRIPTION
This fixes a very minor memory leak, which should only happen one time during boot.

```
ASAN_OPTIONS="detect_leaks=1" RUBY_FREE_AT_EXIT=1 bin/safe-ruby -e 'require "memcached"; 1000.times { lib = Memcached.const_get(:Lib); lib.memcached_create(lib.memcached_create(nil)) }'
-e: warning: Free at exit is experimental and may be unstable

=================================================================
==270021==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 704000 byte(s) in 1000 object(s) allocated from:
    #0 0x561b2c54c789 in calloc (/workspaces/github/vendor/ruby/a1148d4aada8b3bb2e1c370766baad11c28edf23/bin/ruby+0x20e789) (BuildId: 4150ff2af984fe843bd61bcb9247693bf25c58c9)
    #1 0x77c6d5d6e6aa in memcached_create /workspaces/github/vendor/gems/3.4.0/ruby/3.4.0+0/bundler/gems/memcached-9429dfc17895/vendor/libmemcached-0.32/libmemcached/memcached.c:12:26
    #2 0x77c6d5d54fe9 in _wrap_memcached_create /workspaces/github/vendor/gems/3.4.0/ruby/3.4.0+0/bundler/gems/memcached-9429dfc17895/ext/rlibmemcached/rlibmemcached_wrap.c:6955:28
    #3 0x561b2c8d809a in vm_call_cfunc_with_frame_ /workspaces/github/vendor/ruby/src/./vm_insnhelper.c:3795:11
```

A more proper fix might be to make `Lib.memcached_create(existing_struct)` not leak memory, but this is easier and this is an old abandoned branch.