### PR TITLE
WIP - Failure detection always finds first evicted server in array

### DIFF
--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -631,9 +631,13 @@ But it was #{server}.
   # FIXME Is this still necessary with cached_errno?
   def detect_failure
     time = Time.now
-    server = server_structs.detect do |server_struct|
-      server_struct.next_retry > time
+    server = nil
+    server_structs.each do |server_struct|
+      puts "#{inspect_server(server_struct)}: #{server_struct.next_retry}"
+      next unless server_struct.next_retry > time
+      server = server_struct if server.nil? || server_struct.next_retry > server.next_retry
     end
+    puts inspect_server(server)
     inspect_server(server) if server
   end
 


### PR DESCRIPTION
Currently, the behavior of failure detection is to find the first server in the list that's evicted. When multiple servers have been evicted this means it's currently unclear which server was most recently evicted.

I'm not sure if there's a better way to gain insight into eviction behavior, but there are problems with this as well:

* I can't seem to get this to use sub-second resolution, limiting the usefulness.
* It's not clear to me that it's always possible to match evictions to keys as the libary attempts to do at a higher level.